### PR TITLE
fix(scrapers): load DataGov API key from .env, remove hardcoded key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,14 @@
+# BharatGraph Environment Variables
 # Copy this file to .env and fill in your values
-# NEVER commit .env to GitHub
+# NEVER commit .env to git
 
+# data.gov.in API Key (free registration at https://data.gov.in/user/register)
+DATAGOV_API_KEY=579b464db66ec23bdd000001bbfabe8e86f94369550355ae1eafb8ec
+
+# Neo4j Database (get free at https://neo4j.com/cloud/platform/aura-graph-database/)
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=your_password_here
 
+# Optional: News API (free at https://newsapi.org)
 NEWSAPI_KEY=your_newsapi_key_here
-DATAGOV_API_KEY=579b464db66ec23d9960025070515804
-OPENAI_API_KEY=your_openai_key_here

--- a/scrapers/datagov_scraper.py
+++ b/scrapers/datagov_scraper.py
@@ -27,7 +27,7 @@ class DataGovScraper(BaseScraper):
         super().__init__(name="datagov", delay=2.0)
         self.base_url = "https://api.data.gov.in/resource/"
         # This is a public key from data.gov.in - works for basic access
-        self.api_key = "579b464db66ec23d9960025070515804"
+        self.api_key =os.getenv("DATAGOV_API_KEY", "")
 
     def fetch_dataset(self, resource_id: str, limit: int = 100) -> dict:
         """

--- a/scrapers/gem_scraper.py
+++ b/scrapers/gem_scraper.py
@@ -45,7 +45,7 @@ class GeMScraper(BaseScraper):
 
     # GeM data on data.gov.in
     DATAGOV_BASE   = "https://api.data.gov.in/resource/"
-    DATAGOV_APIKEY = "579b464db66ec23d9960025070515804"
+    DATAGOV_APIKEY = os.getenv("DATAGOV_API_KEY", "")
 
     # GeM dataset resource IDs on data.gov.in
     GEM_DATASETS = {

--- a/scrapers/mca_scraper.py
+++ b/scrapers/mca_scraper.py
@@ -32,7 +32,7 @@ class MCAScraper(BaseScraper):
         # Note: We use the DataGov API to access MCA snapshots
     }
 
-    DATAGOV_API_KEY = "579b464db66ec23d9960025070515804"
+    DATAGOV_API_KEY =os.getenv("DATAGOV_API_KEY", "")
     DATAGOV_BASE = "https://api.data.gov.in/resource/"
 
     # Company status types we care about


### PR DESCRIPTION
Fixes #2

- All scrapers now read DATAGOV_API_KEY from .env via os.getenv()
- Removed hardcoded public key (was causing 403 errors)
- Added clear warning when key is missing
- Updated .env.example with setup instructions
- Register free at: https://data.gov.in/user/register