### PR TITLE
fix(security): remove real API key from repo, fix gem_scraper bugs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # BharatGraph Environment Variables
-# Copy this file to .env and fill in your values
-# NEVER commit .env to git
+# Copy this file to .env and fill in your actual values
+# NEVER commit .env to git - only .env.example goes to git
 
-# data.gov.in API Key (free registration at https://data.gov.in/user/register)
-DATAGOV_API_KEY=579b464db66ec23bdd000001bbfabe8e86f94369550355ae1eafb8ec
+# data.gov.in API Key (free at https://data.gov.in/user/register)
+DATAGOV_API_KEY=your_datagov_api_key_here
 
-# Neo4j Database (get free at https://neo4j.com/cloud/platform/aura-graph-database/)
+# Neo4j Database (free at https://neo4j.com/cloud/platform/aura-graph-database/)
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=your_password_here

--- a/config/settings.py
+++ b/config/settings.py
@@ -30,7 +30,7 @@ LOGS_PATH = "logs/"
 
 # Data Sources URLs
 DATAGOV_BASE_URL = "https://api.data.gov.in/resource/"
-DATAGOV_API_KEY = os.getenv("DATAGOV_API_KEY", "579b464db66ec23d9960025070515804")
+DATAGOV_API_KEY = os.getenv("DATAGOV_API_KEY", "")
 PIB_RSS_URL = "https://pib.gov.in/RssMain.aspx?ModId=6&Lang=1&Regid=3"
 MYNETA_BASE_URL = "https://myneta.info"
 MCA_BASE_URL = "https://www.mca.gov.in"

--- a/scrapers/gem_scraper.py
+++ b/scrapers/gem_scraper.py
@@ -3,18 +3,14 @@ BharatGraph - GeM (Government e-Marketplace) Scraper
 Fetches government contract and procurement data.
 Source: gem.gov.in + data.gov.in GeM datasets (public)
 
-WHY THIS IS THE MOST IMPORTANT SCRAPER:
-GeM is where the government buys everything.
-If a politician's relative's company wins contracts here,
-that's exactly the pattern BharatGraph needs to flag.
-
-Pattern we're looking for:
-Politician → (relative/director) → Company → GeM Contract Won
+Pattern we are looking for:
+Politician -> (relative/director) -> Company -> GeM Contract Won
 """
 
+import os
 import json
-import re
 from datetime import datetime
+from collections import defaultdict
 from scrapers.base_scraper import BaseScraper
 from loguru import logger
 
@@ -22,74 +18,56 @@ from loguru import logger
 class GeMScraper(BaseScraper):
     """
     Scrapes procurement contract data from Government e-Marketplace (GeM).
-
     GeM is India's official online procurement portal.
     All government purchases through GeM are public record.
-
-    Data includes:
-    - Contract/order details
-    - Buyer (government department)
-    - Seller (company that won)
-    - Contract value in INR
-    - Product/service category
-    - Order date
-
-    This is critical for finding:
-    - Repeated contract winners
-    - Companies linked to politicians winning contracts
-    - Unusual concentration of contracts
     """
 
-    # GeM public stats API
-    GEM_STATS_URL     = "https://gem.gov.in/statistics"
-    GEM_PUBLIC_API    = "https://mkp.gem.gov.in"
+    GEM_STATS_URL = "https://gem.gov.in/statistics"
+    DATAGOV_BASE  = "https://api.data.gov.in/resource/"
 
-    # GeM data on data.gov.in
-    DATAGOV_BASE   = "https://api.data.gov.in/resource/"
-    DATAGOV_APIKEY = os.getenv("DATAGOV_API_KEY", "")
-
-    # GeM dataset resource IDs on data.gov.in
     GEM_DATASETS = {
         "gem_orders": "0a4b1e09-c3e0-4f0a-8f06-4f62a6d08e4e",
     }
 
     def __init__(self):
         super().__init__(name="gem", delay=2.0)
+        self.api_key = os.getenv("DATAGOV_API_KEY", "")
+        if not self.api_key:
+            logger.warning(
+                "[GeM] No API key! Add DATAGOV_API_KEY to .env "
+                "Register free at: https://data.gov.in/user/register"
+            )
 
     def fetch_gem_stats(self) -> dict:
-    """
-    Fetch public GeM platform statistics.
-    GeM publishes stats at gem.gov.in/statistics (public page).
-    """
-    logger.info("[GeM] Fetching platform statistics...")
+        """
+        Fetch public GeM platform statistics from gem.gov.in/statistics.
+        """
+        logger.info("[GeM] Fetching platform statistics...")
 
-    html = self.get_html("https://gem.gov.in/statistics")
-    if html:
-        logger.success("[GeM] Fetched GeM statistics page")
-        return {
-            "source":     "gem.gov.in/statistics",
-            "scraped_at": datetime.now().isoformat(),
-            "url":        "https://gem.gov.in/statistics",
-            "note":       "Parse HTML for live stats - using sample for now",
-            "stats":      self._get_sample_stats()["stats"],
-        }
+        html = self.get_html(self.GEM_STATS_URL)
+        if html and len(html) > 500:
+            logger.success("[GeM] Fetched GeM statistics page")
+            return {
+                "source":     "gem.gov.in/statistics",
+                "scraped_at": datetime.now().isoformat(),
+                "url":        self.GEM_STATS_URL,
+                "note":       "HTML fetched - using sample stats structure",
+                "stats":      self._get_sample_stats()["stats"],
+            }
 
-    logger.warning("[GeM] Could not fetch stats, using sample")
-    return self._get_sample_stats()
+        logger.warning("[GeM] Could not fetch stats, using sample")
+        return self._get_sample_stats()
 
     def fetch_contracts_by_ministry(self, ministry: str = "all",
                                      limit: int = 50) -> list:
         """
         Fetch procurement contracts, optionally filtered by ministry.
-        Uses data.gov.in GeM dataset.
         """
-        import os
-        api_key = os.getenv("DATAGOV_API_KEY", self.DATAGOV_APIKEY)
         logger.info(f"[GeM] Fetching contracts for ministry: {ministry}")
 
         url = f"{self.DATAGOV_BASE}{self.GEM_DATASETS['gem_orders']}"
         params = {
-            "api-key": api_key,
+            "api-key": self.api_key,
             "format":  "json",
             "limit":   limit,
         }
@@ -107,26 +85,21 @@ class GeMScraper(BaseScraper):
         return self._get_sample_contracts()
 
     def _normalize_contracts(self, records: list) -> list:
-        """Normalize GeM contract records."""
+        """Normalize GeM contract records into standard format."""
         contracts = []
         for rec in records:
             contract = {
-                "order_id":      rec.get("order_id", rec.get("id", "")),
-                "buyer_org":     rec.get("buyer_organisation",
-                                         rec.get("ministry", "")),
-                "seller_name":   rec.get("seller_name",
-                                         rec.get("company_name", "")),
-                "seller_gstin":  rec.get("gstin", ""),
-                "product":       rec.get("product_name",
-                                         rec.get("category", "")),
-                "amount_inr":    rec.get("order_value",
-                                         rec.get("amount", 0)),
-                "order_date":    rec.get("order_date",
-                                         rec.get("date", "")),
-                "state":         rec.get("buyer_state", ""),
-                "source":        "GeM / data.gov.in",
-                "scraped_at":    datetime.now().isoformat(),
-                "entity_type":   "contract",
+                "order_id":     rec.get("order_id",    rec.get("id", "")),
+                "buyer_org":    rec.get("buyer_organisation", rec.get("ministry", "")),
+                "seller_name":  rec.get("seller_name", rec.get("company_name", "")),
+                "seller_gstin": rec.get("gstin", ""),
+                "product":      rec.get("product_name", rec.get("category", "")),
+                "amount_inr":   rec.get("order_value",  rec.get("amount", 0)),
+                "order_date":   rec.get("order_date",   rec.get("date", "")),
+                "state":        rec.get("buyer_state",  ""),
+                "source":       "GeM / data.gov.in",
+                "scraped_at":   datetime.now().isoformat(),
+                "entity_type":  "contract",
             }
             if contract["seller_name"] or contract["order_id"]:
                 contracts.append(contract)
@@ -135,78 +108,72 @@ class GeMScraper(BaseScraper):
     def _get_sample_stats(self) -> dict:
         """Sample GeM statistics for testing."""
         return {
-            "source": "GeM Sample Data",
+            "source":     "GeM Sample Data",
             "scraped_at": datetime.now().isoformat(),
             "stats": {
-                "total_orders": 6200000,
+                "total_orders":    6200000,
                 "total_gmv_crore": 285000,
-                "total_sellers": 680000,
-                "total_buyers": 75000,
+                "total_sellers":   680000,
+                "total_buyers":    75000,
                 "note": "SAMPLE DATA - real stats at gem.gov.in/statistics",
             },
         }
 
     def _get_sample_contracts(self) -> list:
-        """
-        Sample contract structures for graph testing.
-        Shows the type of data we'll eventually link to politicians.
-        """
+        """Sample contract structures for graph testing."""
         return [
             {
-                "order_id":    "GEM/2024/B/12345",
-                "buyer_org":   "Ministry of Rural Development",
-                "seller_name": "SAMPLE INFRASTRUCTURE PVT LTD",
-                "seller_gstin":"33AABCS1234A1Z5",
-                "product":     "Construction Services",
-                "amount_inr":  15000000,
+                "order_id":     "GEM/2024/B/12345",
+                "buyer_org":    "Ministry of Rural Development",
+                "seller_name":  "SAMPLE INFRASTRUCTURE PVT LTD",
+                "seller_gstin": "33AABCS1234A1Z5",
+                "product":      "Construction Services",
+                "amount_inr":   15000000,
                 "amount_crore": 1.5,
-                "order_date":  "2024-03-15",
-                "state":       "Tamil Nadu",
-                "source":      "GeM (sample)",
-                "scraped_at":  datetime.now().isoformat(),
-                "entity_type": "contract",
-                "note":        "SAMPLE - replace with real GeM fetch",
+                "order_date":   "2024-03-15",
+                "state":        "Tamil Nadu",
+                "source":       "GeM (sample)",
+                "scraped_at":   datetime.now().isoformat(),
+                "entity_type":  "contract",
+                "note":         "SAMPLE - replace with real GeM fetch",
             },
             {
-                "order_id":    "GEM/2024/B/67890",
-                "buyer_org":   "Ministry of Health",
-                "seller_name": "SAMPLE MEDICAL SUPPLIES LTD",
-                "seller_gstin":"27AABCM5678B1Z3",
-                "product":     "Medical Equipment",
-                "amount_inr":  50000000,
+                "order_id":     "GEM/2024/B/67890",
+                "buyer_org":    "Ministry of Health",
+                "seller_name":  "SAMPLE MEDICAL SUPPLIES LTD",
+                "seller_gstin": "27AABCM5678B1Z3",
+                "product":      "Medical Equipment",
+                "amount_inr":   50000000,
                 "amount_crore": 5.0,
-                "order_date":  "2024-06-10",
-                "state":       "Maharashtra",
-                "source":      "GeM (sample)",
-                "scraped_at":  datetime.now().isoformat(),
-                "entity_type": "contract",
-                "note":        "SAMPLE - replace with real GeM fetch",
+                "order_date":   "2024-06-10",
+                "state":        "Maharashtra",
+                "source":       "GeM (sample)",
+                "scraped_at":   datetime.now().isoformat(),
+                "entity_type":  "contract",
+                "note":         "SAMPLE - replace with real GeM fetch",
             },
             {
-                "order_id":    "GEM/2024/B/11111",
-                "buyer_org":   "Ministry of Rural Development",
-                "seller_name": "SAMPLE INFRASTRUCTURE PVT LTD",
-                "seller_gstin":"33AABCS1234A1Z5",
-                "product":     "Road Construction",
-                "amount_inr":  80000000,
+                "order_id":     "GEM/2024/B/11111",
+                "buyer_org":    "Ministry of Rural Development",
+                "seller_name":  "SAMPLE INFRASTRUCTURE PVT LTD",
+                "seller_gstin": "33AABCS1234A1Z5",
+                "product":      "Road Construction",
+                "amount_inr":   80000000,
                 "amount_crore": 8.0,
-                "order_date":  "2024-09-20",
-                "state":       "Tamil Nadu",
-                "source":      "GeM (sample)",
-                "scraped_at":  datetime.now().isoformat(),
-                "entity_type": "contract",
-                "note":        "SAMPLE - same company, 2nd contract (pattern!)",
+                "order_date":   "2024-09-20",
+                "state":        "Tamil Nadu",
+                "source":       "GeM (sample)",
+                "scraped_at":   datetime.now().isoformat(),
+                "entity_type":  "contract",
+                "note":         "SAMPLE - same company 2nd contract (pattern!)",
             },
         ]
 
     def find_repeated_winners(self, contracts: list) -> dict:
         """
         Find companies that won multiple contracts.
-        This is a KEY risk indicator - contract concentration.
-
-        Returns dict of {seller_name: [list of contracts]}
+        KEY risk indicator - contract concentration.
         """
-        from collections import defaultdict
         winners = defaultdict(list)
 
         for c in contracts:
@@ -214,23 +181,20 @@ class GeMScraper(BaseScraper):
             if seller:
                 winners[seller].append(c)
 
-        # Only return sellers with 2+ contracts
         repeated = {k: v for k, v in winners.items() if len(v) >= 2}
 
         logger.info(f"[GeM] Repeated contract winners: {len(repeated)}")
-        for seller, contracts_list in repeated.items():
-            total = sum(float(c.get("amount_crore", 0) or 0)
-                       for c in contracts_list)
+        for seller, clist in repeated.items():
+            total = sum(float(c.get("amount_crore", 0) or 0) for c in clist)
             logger.info(
-                f"  → {seller}: {len(contracts_list)} contracts, "
-                f"₹{total:.2f} Cr total"
+                f"  -> {seller}: {len(clist)} contracts, "
+                f"Rs {total:.2f} Cr total"
             )
         return repeated
 
     def fetch_and_save(self, save: bool = True) -> dict:
         """Fetch contracts + stats and save to disk."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-
         stats     = self.fetch_gem_stats()
         contracts = self.fetch_contracts_by_ministry(limit=30)
         repeated  = self.find_repeated_winners(contracts)
@@ -238,10 +202,8 @@ class GeMScraper(BaseScraper):
         result = {
             "stats":            stats,
             "contracts":        contracts,
-            "repeated_winners": {
-                k: v for k, v in repeated.items()
-            },
-            "scraped_at": datetime.now().isoformat(),
+            "repeated_winners": repeated,
+            "scraped_at":       datetime.now().isoformat(),
         }
 
         if save:
@@ -252,7 +214,7 @@ class GeMScraper(BaseScraper):
         return result
 
 
-# ── Run directly to test ──────────────────────────────────────────────────────
+# ── Run directly to test ─────────────────────────────────────────────────────
 if __name__ == "__main__":
     print("=" * 60)
     print("BharatGraph - GeM Contracts Scraper Test")
@@ -264,7 +226,7 @@ if __name__ == "__main__":
     stats = scraper.fetch_gem_stats()
     s = stats.get("stats", {})
     print(f"    Total orders:  {s.get('total_orders', 'N/A'):,}")
-    print(f"    Total GMV:     ₹{s.get('total_gmv_crore', 'N/A'):,} Cr")
+    print(f"    Total GMV:     Rs {s.get('total_gmv_crore', 'N/A'):,} Cr")
     print(f"    Total sellers: {s.get('total_sellers', 'N/A'):,}")
 
     print("\n[2] Fetching contracts...")
@@ -274,21 +236,21 @@ if __name__ == "__main__":
     if contracts:
         c = contracts[0]
         print(f"\n    Example contract:")
-        print(f"    Order ID:    {c.get('order_id')}")
-        print(f"    Buyer:       {c.get('buyer_org')}")
-        print(f"    Seller:      {c.get('seller_name')}")
-        print(f"    Amount:      ₹{c.get('amount_crore')} Cr")
-        print(f"    Date:        {c.get('order_date')}")
+        print(f"    Order ID: {c.get('order_id')}")
+        print(f"    Buyer:    {c.get('buyer_org')}")
+        print(f"    Seller:   {c.get('seller_name')}")
+        print(f"    Amount:   Rs {c.get('amount_crore')} Cr")
+        print(f"    Date:     {c.get('order_date')}")
 
-    print("\n[3] Finding repeated contract winners (risk indicator)...")
+    print("\n[3] Finding repeated contract winners...")
     repeated = scraper.find_repeated_winners(contracts)
     if repeated:
-        print(f"    ⚠️  {len(repeated)} companies won multiple contracts!")
+        print(f"    WARNING: {len(repeated)} companies won multiple contracts!")
     else:
-        print("    No repeated winners found in sample")
+        print("    No repeated winners in sample")
 
     print("\n[4] Saving full data...")
     result = scraper.fetch_and_save(save=True)
-    print(f"    Contracts saved: {len(result['contracts'])}")
+    print(f"    Contracts saved:  {len(result['contracts'])}")
     print(f"    Repeated winners: {len(result['repeated_winners'])}")
-    print("\nDone! Check data/samples/ folder.")
+    print("\nDone!")


### PR DESCRIPTION
Fixes #4

- .env.example: replaced real DATAGOV_API_KEY with placeholder text (real key was accidentally committed - security risk)
- config/settings.py: removed hardcoded key fallback (now empty string)
- gem_scraper.py: fixed 3 bugs:
  1. Added missing 'import os' at top
  2. Fixed empty __init__ - added self.api_key = os.getenv()
  3. Fixed fetch_gem_stats() indentation (body was at class level)
- All 7 scrapers now pass syntax check