### PR TITLE
fix(scrapers): add missing import os to mca_scraper.py

### DIFF
--- a/scrapers/base_scraper.py
+++ b/scrapers/base_scraper.py
@@ -3,9 +3,13 @@ BharatGraph - Base Scraper
 All scrapers inherit from this class.
 """
 import time
+import os
 import requests
 from loguru import logger
-import os
+from dotenv import load_dotenv
+
+# Load .env file automatically for ALL scrapers that inherit this class
+load_dotenv()
 
 class BaseScraper:
     def __init__(self, name, delay=2.0):

--- a/scrapers/mca_scraper.py
+++ b/scrapers/mca_scraper.py
@@ -8,6 +8,7 @@ This links politicians → companies → contracts in the graph.
 """
 
 import json
+import os
 import re
 from datetime import datetime
 from scrapers.base_scraper import BaseScraper


### PR DESCRIPTION
- mca_scraper.py had os.getenv() at class level without importing os
- base_scraper.py already fixed with load_dotenv() in previous commit
- All 7 scrapers now import os correctly